### PR TITLE
v2.7.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "google-resumable-media" %}
-{% set version = "2.7.1" %}
+{% set version = "2.7.2" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eae451a7b2e2cdbaaa0fd2eb00cc8a1ee5e95e16b55597359cbc3d27d7d90e33
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 5280aed4629f2b60b847b0d42f9857fd4935c11af266744df33d8074cae92fe0
 
 build:
   number: 0


### PR DESCRIPTION
google-resumable-media v2.7.1

**Destination channel:** defaults

### Links

- [PKG-7611](https://anaconda.atlassian.net/browse/PKG-7611) 
- [Upstream repository](https://github.com/googleapis/google-resumable-media-python/tree/v2.7.2)


[PKG-7611]: https://anaconda.atlassian.net/browse/PKG-7611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ